### PR TITLE
[4.x] Fix `compare` method callback handling and enforce stricter PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,8 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
+         failOnWarning="true"
+         failOnRisky="true"
 >
     <testsuites>
         <testsuite name="Test Suite">

--- a/src/Benchmark.php
+++ b/src/Benchmark.php
@@ -85,9 +85,9 @@ class Benchmark
     public function compare(array|Closure ...$callbacks): static
     {
         $values = match (true) {
-            is_array($callbacks[0]) => $callbacks[0],
-            is_array($callbacks)    => $callbacks,
-            default                 => func_get_args()
+            is_array($callbacks[0] ?? null) => $callbacks[0],
+            is_array($callbacks)            => $callbacks,
+            default                         => func_get_args()
         };
 
         $this->clear();


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.
In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
